### PR TITLE
Fix code scanning alert no. 8: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/src/main/java/org/brunocvcunha/inutils4j/MyZipUtils.java
+++ b/src/main/java/org/brunocvcunha/inutils4j/MyZipUtils.java
@@ -56,7 +56,11 @@ public class MyZipUtils {
     while (zipEntry != null) {
 
       String neFileNameName = zipEntry.getName();
-      File newFile = new File(outputFolder + File.separator + neFileNameName);
+      File newFile = new File(outputFolder, neFileNameName).getCanonicalFile();
+
+      if (!newFile.getPath().startsWith(outputFolder.getCanonicalPath())) {
+        throw new IOException("Bad zip entry: " + neFileNameName);
+      }
 
       newFile.getParentFile().mkdirs();
 


### PR DESCRIPTION
Fixes [https://github.com/bvolpato/inutils4j/security/code-scanning/8](https://github.com/bvolpato/inutils4j/security/code-scanning/8)

To fix the problem, we need to ensure that the file paths constructed from zip entry names are validated to prevent directory traversal attacks. This can be achieved by normalizing the file paths and ensuring they start with the intended output directory path.

1. Normalize the file path created from the zip entry name.
2. Check if the normalized path starts with the intended output directory path.
3. If the check fails, throw an exception to prevent writing the file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
